### PR TITLE
Add Union territory to approved state types

### DIFF
--- a/django_global_places/management/commands/populate_global_places.py
+++ b/django_global_places/management/commands/populate_global_places.py
@@ -54,7 +54,8 @@ class Command(BaseCommand):
     approved_state_types = [
         'state','province', 'metropolitan region', 'Region', 'region', None,
         'territory','canton','department','federal district','capital city',
-        'autonomous region', 'autonomous community','autonomous region','republic'
+        'autonomous region', 'autonomous community','autonomous region','republic',
+        'Union territory'
         ]
 
     extra_pos = 1 \


### PR DESCRIPTION
The script skips the import of regions that are `Union territory`. They can be considered as _states_, as they are neither a country nor a city. This behaviour is consistent with the [dr5hn](https://dr5hn.github.io/countries-states-cities-database/) web demo, which this library uses as the data source.
For example, see `"id": 4021`